### PR TITLE
Better OS-checker for the install script

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -21,6 +21,7 @@ fi
 # Convert to lowercase
 OS=$(echo $OS | tr '[:upper:]' '[:lower:]')
 
+echo $OS
 case $OS in
     "arch"|"archlinux"|"endeavouros")
         # Arch Linux commands

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -44,23 +44,23 @@ case $OS in
         
 # For most Linux Distros
 # Detect Package Manager
-if command -v pacman ; then
+if $(command -v pacman) ; then
 # Arch Linux commands
     echo "Detected Arch Linux"
     sudo pacman -S python-virtualenv git
     ;;
-elif command -v apt ; then 
+elif $(command -v apt) ; then 
 # Ubuntu commands
     echo "Detected Ubuntu/Debian"
     sudo apt-get update
     sudo apt-get install build-essential cmake python3-dev libssl-dev qtbase5-dev qtdeclarative5-dev qttools5-dev libqt5svg5-dev qt5-default git wget python3-venv -y
     ;;
-elif command -v dnf ; then
+elif $(command -v dnf) ; then
 # Fedora commands
     echo "Detected Fedora"
     sudo dnf install -y git python3-virtualenv qt5-devel
     ;;
-elif command -v zypper ; then
+elif $(command -v zypper) ; then
 # OpenSUSE commands
     echo "Detected OpenSUSE"
     sudo zypper install -y git python3-virtualenv libqt5-qtbase-devel

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -41,32 +41,29 @@ case $OS in
         fi
         brew install python3 git
         ;;
+    esac
         
 # For most Linux Distros
 # Detect Package Manager
-if [command -v pacman ]; then
+if command -v pacman ; then
 # Arch Linux commands
     echo "Detected Arch Linux"
     sudo pacman -S python-virtualenv git
-    ;;
-elif [ command -v apt ]; then 
+elif  command -v apt ; then 
 # Ubuntu commands
     echo "Detected Ubuntu/Debian"
     sudo apt-get update
     sudo apt-get install build-essential cmake python3-dev libssl-dev qtbase5-dev qtdeclarative5-dev qttools5-dev libqt5svg5-dev qt5-default git wget python3-venv -y
-    ;;
-elif [ command -v dnf ]; then
+elif  command -v dnf ; then
 # Fedora commands
     echo "Detected Fedora"
     sudo dnf install -y git python3-virtualenv qt5-devel
-    ;;
-elif [ command -v zypper ]; then
+elif  command -v zypper ; then
 # OpenSUSE commands
     echo "Detected OpenSUSE"
     sudo zypper install -y git python3-virtualenv libqt5-qtbase-devel
-    ;;
+fi
 
-esac
 
 # Common commands
 git clone https://github.com/EchterAlsFake/Porn_Fetch

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,12 +22,12 @@ fi
 OS=$(echo $OS | tr '[:upper:]' '[:lower:]')
 
 case $OS in
-    "arch"|"archlinux")
+    "arch"|"archlinux"|"endeavouros")
         # Arch Linux commands
         echo "Detected Arch Linux"
         sudo pacman -S python-virtualenv git
         ;;
-    "ubuntu")
+    "ubuntu"|"linuxmint")
         # Ubuntu commands
         echo "Detected Ubuntu"
         sudo apt-get update

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -44,23 +44,23 @@ case $OS in
         
 # For most Linux Distros
 # Detect Package Manager
-if $(command -v pacman) ; then
+if [command -v pacman ]; then
 # Arch Linux commands
     echo "Detected Arch Linux"
     sudo pacman -S python-virtualenv git
     ;;
-elif $(command -v apt) ; then 
+elif [ command -v apt ]; then 
 # Ubuntu commands
     echo "Detected Ubuntu/Debian"
     sudo apt-get update
     sudo apt-get install build-essential cmake python3-dev libssl-dev qtbase5-dev qtdeclarative5-dev qttools5-dev libqt5svg5-dev qt5-default git wget python3-venv -y
     ;;
-elif $(command -v dnf) ; then
+elif [ command -v dnf ]; then
 # Fedora commands
     echo "Detected Fedora"
     sudo dnf install -y git python3-virtualenv qt5-devel
     ;;
-elif $(command -v zypper) ; then
+elif [ command -v zypper ]; then
 # OpenSUSE commands
     echo "Detected OpenSUSE"
     sudo zypper install -y git python3-virtualenv libqt5-qtbase-devel

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Automatic compile script
-# Detect distribution
+# If not on a Linux distro, the OS name is used to ensure compatibility
+
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     OS=$ID
@@ -21,35 +22,13 @@ fi
 # Convert to lowercase
 OS=$(echo $OS | tr '[:upper:]' '[:lower:]')
 
-echo $OS
 case $OS in
-    "arch"|"archlinux"|"endeavouros")
-        # Arch Linux commands
-        echo "Detected Arch Linux"
-        sudo pacman -S python-virtualenv git
-        ;;
-    "ubuntu"|"linuxmint")
-        # Ubuntu commands
-        echo "Detected Ubuntu"
-        sudo apt-get update
-        sudo apt-get install build-essential cmake python3-dev libssl-dev qtbase5-dev qtdeclarative5-dev qttools5-dev libqt5svg5-dev qt5-default git wget python3-venv -y
-        ;;
     "termux")
         # Termux commands
         echo "Detected Termux"
         apt-get update
         apt-get full-upgrade -y
         apt-get install python3 python-pip git wget ldd binutils
-        ;;
-    "fedora")
-        # Fedora commands
-        echo "Detected Fedora"
-        sudo dnf install -y git python3-virtualenv qt5-devel
-        ;;
-    "opensuse"|"suse")
-        # OpenSUSE commands
-        echo "Detected OpenSUSE"
-        sudo zypper install -y git python3-virtualenv libqt5-qtbase-devel
         ;;
     "darwin")
         # macOS commands
@@ -62,10 +41,31 @@ case $OS in
         fi
         brew install python3 git
         ;;
-    *)
-        echo "Unsupported distribution: $OS"
-        exit 1
-        ;;
+        
+# For most Linux Distros
+# Detect Package Manager
+if command -v pacman ; then
+# Arch Linux commands
+    echo "Detected Arch Linux"
+    sudo pacman -S python-virtualenv git
+    ;;
+elif command -v apt ; then 
+# Ubuntu commands
+    echo "Detected Ubuntu/Debian"
+    sudo apt-get update
+    sudo apt-get install build-essential cmake python3-dev libssl-dev qtbase5-dev qtdeclarative5-dev qttools5-dev libqt5svg5-dev qt5-default git wget python3-venv -y
+    ;;
+elif command -v dnf ; then
+# Fedora commands
+    echo "Detected Fedora"
+    sudo dnf install -y git python3-virtualenv qt5-devel
+    ;;
+elif command -v zypper ; then
+# OpenSUSE commands
+    echo "Detected OpenSUSE"
+    sudo zypper install -y git python3-virtualenv libqt5-qtbase-devel
+    ;;
+
 esac
 
 # Common commands


### PR DESCRIPTION
I made an improvement in how the OS checking portion of the script determines what build tools to use. It will detect whether a package manager [pacman, apt, dnf, zypper] is installed on the target system, and then uses the build script for that package manager. 

Currently this has been tested on EndeavourOS and Ubuntu (on the metal) and Arch, Mint, and Debian (in VMs). I expect it to also run fine on Fedora and SUSE but I have not tested these yet. I also read that you intend to switch from Pyinstaller to pyside6-deploy, and I hope that is a success.

